### PR TITLE
add default wrapper implementations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,7 @@ categories = ["concurrency"]
 
 [dev-dependencies]
 pin-project-lite = "0.2.7"
+futures = { version = "0.3" }
+
+[dependencies]
+futures-core = { version = "0.3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ pin-project-lite = "0.2.7"
 futures = { version = "0.3" }
 
 [dependencies]
-futures-core = { version = "0.3" }
+futures-core = { version = "0.3", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,26 +184,25 @@ impl<T> From<T> for SyncWrapper<T> {
     }
 }
 
-
+/// `Future` which is `Sync`.
+///
+/// # Examples
+///
+/// ```
+/// use sync_wrapper::{SyncWrapper, SyncFuture};
+///
+/// let fut = async { 1 };
+/// let fut = SyncFuture::new(fut);
+/// ```
 pub struct SyncFuture<F> {
     inner: SyncWrapper<F>
 }
 impl <F: Future> SyncFuture<F> {
-    /// Create a `Future` which is `Sync`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use sync_wrapper::{SyncWrapper, SyncFuture};
-    ///
-    /// let fut = async { 1 };
-    /// let fut = SyncFuture::new(fut);
-    /// ```
     pub fn new(inner: F) -> Self {
         Self { inner: SyncWrapper::new(inner) }
     }
-    pub fn into_inner(self) -> SyncWrapper<F> {
-        self.inner
+    pub fn into_inner(self) -> F {
+        self.inner.into_inner()
     }
 }
 impl <F: Future> Future for SyncFuture<F> {
@@ -214,26 +213,26 @@ impl <F: Future> Future for SyncFuture<F> {
     }
 }
 
+/// `Stream` which is `Sync`.
+///
+/// # Examples
+///
+/// ```
+/// use sync_wrapper::SyncStream;
+/// use futures::stream;
+///
+/// let st = stream::iter(vec![1]);
+/// let st = SyncStream::new(st);
+/// ```
 pub struct SyncStream<S> {
     inner: SyncWrapper<S>
 }
 impl <S: futures_core::Stream> SyncStream<S> {
-    /// Create a `Stream` which is `Sync`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use sync_wrapper::SyncStream;
-    /// use futures::stream;
-    ///
-    /// let st = stream::iter(vec![1]);
-    /// let st = SyncStream::new(st);
-    /// ```
     pub fn new(inner: S) -> Self {
         Self { inner: SyncWrapper::new(inner) }
     }
-    pub fn into_inner(self) -> SyncWrapper<S> {
-        self.inner
+    pub fn into_inner(self) -> S {
+        self.inner.into_inner()
     }
 }
 impl <S: futures_core::Stream> futures_core::Stream for SyncStream<S> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,8 @@
 use core::{
     fmt::{self, Debug, Formatter},
     pin::Pin,
+    future::Future,
+    task::{Context, Poll},
 };
 
 /// A mutual exclusion primitive that relies on static type information only
@@ -179,5 +181,65 @@ impl<T: Default> Default for SyncWrapper<T> {
 impl<T> From<T> for SyncWrapper<T> {
     fn from(value: T) -> Self {
         Self::new(value)
+    }
+}
+
+
+pub struct SyncFuture<F> {
+    inner: SyncWrapper<F>
+}
+impl <F: Future> SyncFuture<F> {
+    /// Create a `Future` which is `Sync`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sync_wrapper::{SyncWrapper, SyncFuture};
+    ///
+    /// let fut = async { 1 };
+    /// let fut = SyncFuture::new(fut);
+    /// ```
+    pub fn new(inner: F) -> Self {
+        Self { inner: SyncWrapper::new(inner) }
+    }
+    pub fn into_inner(self) -> SyncWrapper<F> {
+        self.inner
+    }
+}
+impl <F: Future> Future for SyncFuture<F> {
+    type Output = F::Output;
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let inner = unsafe { self.map_unchecked_mut(|x| x.inner.get_mut()) };
+        inner.poll(cx)
+    }
+}
+
+pub struct SyncStream<S> {
+    inner: SyncWrapper<S>
+}
+impl <S: futures_core::Stream> SyncStream<S> {
+    /// Create a `Stream` which is `Sync`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sync_wrapper::SyncStream;
+    /// use futures::stream;
+    ///
+    /// let st = stream::iter(vec![1]);
+    /// let st = SyncStream::new(st);
+    /// ```
+    pub fn new(inner: S) -> Self {
+        Self { inner: SyncWrapper::new(inner) }
+    }
+    pub fn into_inner(self) -> SyncWrapper<S> {
+        self.inner
+    }
+}
+impl <S: futures_core::Stream> futures_core::Stream for SyncStream<S> {
+    type Item = S::Item;
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let inner = unsafe { self.map_unchecked_mut(|x| x.inner.get_mut()) };
+        inner.poll_next(cx)
     }
 }


### PR DESCRIPTION
This PR adds default wrapper implementations for `Future` and `Stream`.

This crate is typically used to add `Sync` to these two traits so it is good to have default implementations.

Also, as this is a library crate let's untrack Cargo.lock file.