### PR TITLE
Remove the `T : Send` bound for `SyncWrapper` to be `Sync`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,4 +123,4 @@ impl<T> SyncWrapper<T> {
 
 // this is safe because the only operations permitted on this data structure require exclusive
 // access or ownership
-unsafe impl<T: Send> Sync for SyncWrapper<T> {}
+unsafe impl<T> Sync for SyncWrapper<T> {}


### PR DESCRIPTION
Indeed, it is not necessary: `Inner : Send => Wrapper : Sync` is only required for `Wrapper`s allowing `&Wrapper -> &mut Inner` code paths such as `Mutex` or, less obviously, `Arc`