### PR TITLE
Implement `Debug`, `Default` and `From<T>` for `SyncWrapper`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,3 +132,9 @@ impl<T> Debug for SyncWrapper<T> {
         f.pad("SyncWrapper")
     }
 }
+
+impl<T: Default> Default for SyncWrapper<T> {
+    fn default() -> Self {
+        Self::new(T::default())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,8 @@
 #![doc(html_logo_url = "https://developer.actyx.com/img/logo.svg")]
 #![doc(html_favicon_url = "https://developer.actyx.com/img/favicon.ico")]
 
+use core::fmt::{self, Debug, Formatter};
+
 /// A mutual exclusion primitive that relies on static type information only
 ///
 /// In some cases synchronization can be proven statically: whenever you hold an exclusive `&mut`
@@ -124,3 +126,9 @@ impl<T> SyncWrapper<T> {
 // this is safe because the only operations permitted on this data structure require exclusive
 // access or ownership
 unsafe impl<T> Sync for SyncWrapper<T> {}
+
+impl<T> Debug for SyncWrapper<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.pad("SyncWrapper")
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,3 +138,9 @@ impl<T: Default> Default for SyncWrapper<T> {
         Self::new(T::default())
     }
 }
+
+impl<T> From<T> for SyncWrapper<T> {
+    fn from(value: T) -> Self {
+        Self::new(value)
+    }
+}


### PR DESCRIPTION
These traits are also present on `Mutex`.