### PR TITLE
Fix a soundness hole

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,7 +164,7 @@ impl<T> SyncWrapper<T> {
 
 // this is safe because the only operations permitted on this data structure require exclusive
 // access or ownership
-unsafe impl<T> Sync for SyncWrapper<T> {}
+unsafe impl<T: Send> Sync for SyncWrapper<T> {}
 
 impl<T> Debug for SyncWrapper<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
Just like `Mutex<T>` is only `Sync` if `T` is `Send`, `SyncWrapper<T>` should contain the same constraints.

See https://github.com/rust-lang/rust/pull/106792 for an example of how this can play out in practice.