### PR TITLE
Enable `futures` feature in docs.rs build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,7 @@ futures = { version = "0.3" }
 
 [dependencies]
 futures-core = { version = "0.3", default-features = false, optional = true }
+
+[package.metadata.docs.rs]
+features = ["futures"]
+


### PR DESCRIPTION
This makes `SyncStream` appear on docs.rs, which currently doesn't https://docs.rs/sync_wrapper/1.0.0/sync_wrapper/index.html

See https://docs.rs/about/metadata